### PR TITLE
fix(functions): set header "Access-Control-Allow-Methods" to "*"

### DIFF
--- a/functions/constants.ts
+++ b/functions/constants.ts
@@ -1,0 +1,5 @@
+export enum CORS_HEADERS {
+  ACCESS_CONTROL_ALLOW_HEADERS = 'Access-Control-Allow-Headers',
+  ACCESS_CONTROL_ALLOW_METHODS = 'Access-Control-Allow-Methods',
+  ACCESS_CONTROL_ALLOW_ORIGIN = 'Access-Control-Allow-Origin',
+}

--- a/functions/v1.ts
+++ b/functions/v1.ts
@@ -1,3 +1,5 @@
+import { CORS_HEADERS } from './constants';
+
 /**
  * @see {@link https://developers.cloudflare.com/workers/examples/cors-header-proxy/}
  */
@@ -16,7 +18,9 @@ export const onRequest: PagesFunction = async (context) => {
   response = new Response(response.body, response);
 
   // Set CORS headers
-  response.headers.set('Access-Control-Allow-Origin', '*');
+  Object.values(CORS_HEADERS).forEach((header) => {
+    response.headers.set(header, '*');
+  });
 
   // Append to/Add Vary header so browser will cache response correctly
   response.headers.append('Vary', 'Origin');
@@ -29,9 +33,9 @@ export const onRequest: PagesFunction = async (context) => {
  */
 export const onRequestOptions: PagesFunction = async () => {
   return new Response(null, {
-    headers: {
-      'Access-Control-Allow-Origin': '*',
-      'Access-Control-Allow-Headers': '*',
-    },
+    headers: Object.values(CORS_HEADERS).reduce((accumulator, currentValue) => {
+      accumulator[currentValue] = '*';
+      return accumulator;
+    }, {}),
   });
 };


### PR DESCRIPTION
https://developers.cloudflare.com/workers/examples/cors-header-proxy/

This fixes errors like:

```
Access to fetch at 'http://127.0.0.1:8788/test' from origin 'http://localhost:5173' has been blocked by CORS policy: Method DELETE is not allowed by Access-Control-Allow-Methods in preflight response.
```

```
[mf:inf] OPTIONS /test 405 Method Not Allowed
```