### PR TITLE
feat(functions): add rate limiting using Cloudflare Rate Limiting API

### DIFF
--- a/functions/v1.ts
+++ b/functions/v1.ts
@@ -1,6 +1,16 @@
-import { BAD_REQUEST } from 'costatus';
+import { BAD_REQUEST, TOO_MANY_REQUESTS } from 'costatus';
 
 import { CORS_HEADERS } from './constants';
+
+interface RateLimit {
+  limit(options: { key: string }): Promise<{
+    success: boolean;
+  }>;
+}
+
+interface Env {
+  RATE_LIMITER: RateLimit;
+}
 
 /**
  * GET|HEAD|POST|PUT|DELETE|PATCH /v1
@@ -10,7 +20,22 @@ import { CORS_HEADERS } from './constants';
  * @param context - Context.
  * @returns - Response.
  */
-export const onRequest: PagesFunction = async (context) => {
+export const onRequest: PagesFunction<Env> = async (context) => {
+  // Check rate limit using client IP
+  const clientIP = context.request.headers.get('CF-Connecting-IP') || 'unknown';
+  const rateLimitResult = await context.env.RATE_LIMITER.limit({
+    key: clientIP,
+  });
+
+  if (!rateLimitResult.success) {
+    return new Response('Rate limit exceeded. Try again later.', {
+      status: TOO_MANY_REQUESTS,
+      headers: {
+        'Content-Type': 'text/plain',
+      },
+    });
+  }
+
   const url = new URL(context.request.url).searchParams.get('url');
 
   if (!url) {

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -1,0 +1,12 @@
+{
+  "ratelimits": [
+    {
+      "name": "RATE_LIMITER",
+      "namespace_id": "1001",
+      "simple": {
+        "limit": 100,
+        "period": 60
+      }
+    }
+  ]
+}


### PR DESCRIPTION
<!--
Filling out the information below can facilitate the review/merge of the pull request (PR).
-->

## What is the motivation for this pull request?

Feature: Add rate limiting to protect the CORS proxy from abuse

https://developers.cloudflare.com/workers/runtime-apis/bindings/rate-limit/

## What is the current behavior?

No rate limiting - unlimited requests allowed per IP

## What is the new behavior?

Rate limiting (100 requests per minute per IP) using Cloudflare's native Rate Limiting API:
- Returns 429 when limit exceeded
- Uses `CF-Connecting-IP` for client identification

## Test Plan

```sh
# Rapid requests to trigger limit
for i in {1..110}; do 
  curl -s -o /dev/null -w "%{http_code}\n" \
    https://feat-ratelimits.corsmirror.pages.dev/v1?url=https://httpbin.org/get
  sleep 0.1
done
```

## Checklist:

<!--
Feel free to remove any item that is irrelevant to your changes.
To check an item, place an "x" in the box like so: `- [x] Tests`
-->

- [x] [Conventional Commits](https://www.conventionalcommits.org/)
- [ ] Tests
- [ ] Documentation

<!--
Any other comments? Thank you for contributing!
-->