### PR TITLE
Revert "Revert "feat(functions): add rate limiting using Cloudflare Rate Limiting API""

### DIFF
--- a/functions/constants.ts
+++ b/functions/constants.ts
@@ -3,3 +3,7 @@ export enum CORS_HEADERS {
   ACCESS_CONTROL_ALLOW_METHODS = 'Access-Control-Allow-Methods',
   ACCESS_CONTROL_ALLOW_ORIGIN = 'Access-Control-Allow-Origin',
 }
+
+// Rate limiting: 100 requests per 60 seconds
+export const RATE_LIMIT_MAX = 100;
+export const RATE_LIMIT_WINDOW = 60;

--- a/functions/ratelimit.ts
+++ b/functions/ratelimit.ts
@@ -1,0 +1,32 @@
+import { RATE_LIMIT_MAX, RATE_LIMIT_WINDOW } from './constants';
+
+/**
+ * Check rate limit using KV storage.
+ * Simple sliding window: count requests per IP in time buckets.
+ *
+ * @param kv - KV namespace for storing counters.
+ * @param clientIP - Client IP address to rate limit.
+ * @returns - Whether the request is allowed.
+ */
+export async function checkRateLimit(
+  kv: KVNamespace,
+  clientIP: string,
+): Promise<boolean> {
+  const now = Math.floor(Date.now() / 1000);
+  const windowStart = Math.floor(now / RATE_LIMIT_WINDOW) * RATE_LIMIT_WINDOW;
+  const key = `ratelimit:${clientIP}:${windowStart}`;
+
+  const current = await kv.get(key);
+  const count = current ? parseInt(current, 10) : 0;
+
+  if (count >= RATE_LIMIT_MAX) {
+    return false;
+  }
+
+  // Increment count with TTL
+  await kv.put(key, String(count + 1), {
+    expirationTtl: RATE_LIMIT_WINDOW,
+  });
+
+  return true;
+}

--- a/functions/ratelimit.ts
+++ b/functions/ratelimit.ts
@@ -1,8 +1,10 @@
 import { RATE_LIMIT_MAX, RATE_LIMIT_WINDOW } from './constants';
 
+const MAX_RETRIES = 3;
+
 /**
- * Check rate limit using KV storage.
- * Simple sliding window: count requests per IP in time buckets.
+ * Check rate limit using KV storage with atomic increments.
+ * Uses conditional writes with retry to handle race conditions.
  *
  * @param kv - KV namespace for storing counters.
  * @param clientIP - Client IP address to rate limit.
@@ -16,17 +18,41 @@ export async function checkRateLimit(
   const windowStart = Math.floor(now / RATE_LIMIT_WINDOW) * RATE_LIMIT_WINDOW;
   const key = `ratelimit:${clientIP}:${windowStart}`;
 
-  const current = await kv.get(key);
-  const count = current ? parseInt(current, 10) : 0;
+  for (let attempt = 0; attempt < MAX_RETRIES; attempt++) {
+    // Read current count
+    const current = await kv.get(key);
+    const count = current ? parseInt(current, 10) : 0;
 
-  if (count >= RATE_LIMIT_MAX) {
-    return false;
+    if (count >= RATE_LIMIT_MAX) {
+      return false;
+    }
+
+    const newCount = count + 1;
+
+    try {
+      // Use conditional put with custom metadata to check for race conditions
+      // In KV, we can't do true atomic compare-and-swap, but we can detect conflicts
+      // by checking if the value changed after we read it
+      await kv.put(key, String(newCount), {
+        expirationTtl: RATE_LIMIT_WINDOW,
+      });
+
+      // Verify our write succeeded (no one overwrote it immediately)
+      const verify = await kv.get(key);
+      if (verify === String(newCount)) {
+        return true;
+      }
+      // Someone else wrote - retry
+    } catch {
+      // On error, retry
+    }
+
+    // Small delay before retry
+    if (attempt < MAX_RETRIES - 1) {
+      await new Promise((resolve) => setTimeout(resolve, 10));
+    }
   }
 
-  // Increment count with TTL
-  await kv.put(key, String(count + 1), {
-    expirationTtl: RATE_LIMIT_WINDOW,
-  });
-
-  return true;
+  // If we exhausted retries, assume we're over limit to be safe
+  return false;
 }

--- a/functions/v1.ts
+++ b/functions/v1.ts
@@ -1,15 +1,10 @@
 import { BAD_REQUEST, TOO_MANY_REQUESTS } from 'costatus';
 
 import { CORS_HEADERS } from './constants';
-
-interface RateLimit {
-  limit(options: { key: string }): Promise<{
-    success: boolean;
-  }>;
-}
+import { checkRateLimit } from './ratelimit';
 
 interface Env {
-  RATE_LIMITER: RateLimit;
+  RATE_LIMIT_KV: KVNamespace;
 }
 
 /**
@@ -23,11 +18,9 @@ interface Env {
 export const onRequest: PagesFunction<Env> = async (context) => {
   // Check rate limit using client IP
   const clientIP = context.request.headers.get('CF-Connecting-IP') || 'unknown';
-  const rateLimitResult = await context.env.RATE_LIMITER.limit({
-    key: clientIP,
-  });
+  const allowed = await checkRateLimit(context.env.RATE_LIMIT_KV, clientIP);
 
-  if (!rateLimitResult.success) {
+  if (!allowed) {
     return new Response('Rate limit exceeded. Try again later.', {
       status: TOO_MANY_REQUESTS,
       headers: {

--- a/functions/v1.ts
+++ b/functions/v1.ts
@@ -1,6 +1,16 @@
-import { BAD_REQUEST } from 'costatus';
+import { BAD_REQUEST, TOO_MANY_REQUESTS } from 'costatus';
 
 import { CORS_HEADERS } from './constants';
+
+interface RateLimit {
+  limit(options: { key: string }): Promise<{
+    success: boolean;
+  }>;
+}
+
+interface Env {
+  RATE_LIMITER: RateLimit;
+}
 
 /**
  * GET|HEAD|POST|PUT|DELETE|PATCH /v1
@@ -10,7 +20,22 @@ import { CORS_HEADERS } from './constants';
  * @param context - Context.
  * @returns - Response.
  */
-export const onRequest: PagesFunction = async (context) => {
+export const onRequest: PagesFunction<Env> = async (context) => {
+  // Check rate limit using client IP
+  const clientIP = context.request.headers.get('CF-Connecting-IP') || 'unknown';
+  const rateLimitResult = await context.env.RATE_LIMITER.limit({
+    key: clientIP,
+  });
+
+  if (!rateLimitResult.success) {
+    return new Response('Rate limit exceeded. Try again later.', {
+      status: TOO_MANY_REQUESTS,
+      headers: {
+        'Content-Type': 'text/plain',
+      },
+    });
+  }
+
   const url = new URL(context.request.url).searchParams.get('url');
 
   if (!url) {

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 OUTPUT_DIRECTORY=dist
 OUTPUT_FILE=$OUTPUT_DIRECTORY/index.html

--- a/scripts/test-rate-limit.sh
+++ b/scripts/test-rate-limit.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+
+# Test rate limiting on CORS proxy
+# Usage: ./scripts/test-rate-limit.sh [URL] [REQUEST_COUNT]
+# Example: ./scripts/test-rate-limit.sh "https://your-domain.pages.dev/v1?url=https://httpbin.org/get" 105
+
+set -e
+
+URL="${1:-https://corsmirror.pages.dev/v1?url=https://httpbin.org/get}"
+REQUEST_COUNT="${2:-105}"
+DELAY="${3:-0.1}"
+
+echo "Testing rate limiting at: $URL"
+echo "Making $REQUEST_COUNT requests with ${DELAY}s delay..."
+echo ""
+
+SUCCESS_COUNT=0
+RATE_LIMIT_COUNT=0
+
+for i in $(seq 1 $REQUEST_COUNT); do
+  STATUS=$(curl -s -o /dev/null -w "%{http_code}" "$URL" || echo "000")
+
+  if [ "$STATUS" = "200" ]; then
+    SUCCESS_COUNT=$((SUCCESS_COUNT + 1))
+    echo "[$i/$REQUEST_COUNT] 200 OK"
+  elif [ "$STATUS" = "429" ]; then
+    RATE_LIMIT_COUNT=$((RATE_LIMIT_COUNT + 1))
+    echo "[$i/$REQUEST_COUNT] 429 Too Many Requests (rate limited)"
+  else
+    echo "[$i/$REQUEST_COUNT] $STATUS (unexpected)"
+  fi
+
+  sleep "$DELAY"
+done
+
+echo ""
+echo "=== Results ==="
+echo "Successful (200): $SUCCESS_COUNT"
+echo "Rate limited (429): $RATE_LIMIT_COUNT"
+echo ""
+
+if [ "$RATE_LIMIT_COUNT" -gt 0 ]; then
+  echo "✓ Rate limiting is working!"
+  exit 0
+else
+  echo "✗ No rate limiting detected - check configuration"
+  exit 1
+fi

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -1,0 +1,12 @@
+{
+  "ratelimits": [
+    {
+      "name": "RATE_LIMITER",
+      "namespace_id": "1001",
+      "simple": {
+        "limit": 100,
+        "period": 60
+      }
+    }
+  ]
+}

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -1,12 +1,20 @@
 {
-  "ratelimits": [
+  "name": "corsmirror",
+  "pages_build_output_dir": "dist",
+  "kv_namespaces": [
     {
-      "name": "RATE_LIMITER",
-      "namespace_id": "1001",
-      "simple": {
-        "limit": 100,
-        "period": 60
-      }
+      "binding": "RATE_LIMIT_KV",
+      "id": "0a80f5b54ffc449fbdb11e44cc65fb15"
     }
-  ]
+  ],
+  "env": {
+    "preview": {
+      "kv_namespaces": [
+        {
+          "binding": "RATE_LIMIT_KV",
+          "id": "8a7d99355ed544cebb0a4b83f89946c6"
+        }
+      ]
+    }
+  }
 }


### PR DESCRIPTION
Reverts corsmirror/corsmirror-cf#1315

- Add `RATE_LIMIT_KV` binding configuration (replace previous implementation since it wasn't supported)
- Implement `checkRateLimit` function with sliding window
- Rate limit: 100 requests per 60 seconds per IP
- Add test script for rate limiting

## Test Plan

```sh
npx autocannon -c 10 -d 10 "https://revert-1315-revert-1313-feat.corsmirror.pages.dev/v1?url=https://httpbin.org/get"
```