### PR TITLE
fix: handle invalid proxy URLs

### DIFF
--- a/cypress/e2e/v1/v1.feature
+++ b/cypress/e2e/v1/v1.feature
@@ -5,6 +5,12 @@ Feature: v1
     Then I see response status 400
       And I see response body "Invalid URL string."
 
+  Scenario: I get 400 error when I pass an invalid URL
+    Given I make a "GET" request to "/v1?url=not-a-url"
+      | failOnStatusCode | false |
+    Then I see response status 400
+      And I see response body "Invalid URL string."
+
   Scenario: I see example page
     Given I visit "/v1?url=http://example.com"
       | failOnStatusCode | false |

--- a/functions/v1.ts
+++ b/functions/v1.ts
@@ -19,11 +19,20 @@ export const onRequest: PagesFunction = async (context) => {
     });
   }
 
+  let targetUrl: URL;
+  try {
+    targetUrl = new URL(url);
+    context.request = new Request(targetUrl.toString(), context.request);
+  } catch {
+    return new Response('Invalid URL string.', {
+      status: BAD_REQUEST,
+    });
+  }
+
   // Rewrite request to point to target URL.
   // This also makes the request mutable so you can add the correct
   // Origin header to make the API server think that this request is not cross-site.
-  context.request = new Request(url, context.request);
-  context.request.headers.set('Origin', new URL(url).origin);
+  context.request.headers.set('Origin', targetUrl.origin);
 
   // Recreate the response so you can modify the headers
   let response = await fetch(context.request);


### PR DESCRIPTION
## Summary
- return 400 Bad Request when the supplied proxy URL cannot be parsed or used as a Request target
- add a Cypress regression scenario for a malformed url query parameter

## Checks
- npm run lint:tsc
- npx eslint functions/v1.ts
- git diff --check

Full-repo npm run lint still reports existing CRLF formatting errors across the Windows checkout, including untouched files.